### PR TITLE
Update README to mention mise.toml and vim editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,16 @@
-# Macos Setups
-- oh my zsh
-- brew
-- MacOS git
-- node.js, elixir, golang in .zshrc
-- thefuck
-- git cz
-- tiddlywiki
-- vscode, firefox, iterm2
-- postgresql
-- mise.toml for tool versions (elixir, erlang, go, node, npm, python, ruby)
-- Git config syncing & default editor set to vim
+# ThaddeusJiang's macOS Setups
+
+```sh
+./setup.sh
+```
+
+```sh
+mise install
+```
+
+```sh
+cp -f .gitconfig ~/.gitconfig
+cp -f .gitignore_global ~/.gitignore_global
+
+
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # Macos Setups
-
 - oh my zsh
 - brew
 - MacOS git
@@ -9,3 +8,5 @@
 - tiddlywiki
 - vscode, firefox, iterm2
 - postgresql
+- mise.toml for tool versions (elixir, erlang, go, node, npm, python, ruby)
+- Git config syncing & default editor set to vim


### PR DESCRIPTION
This PR updates the README to include new bullet points for the newly added mise.toml tool version management file and the Git default editor setup using vim.